### PR TITLE
fix: change back the default image_inner method

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -339,6 +339,11 @@ class SageMakerUI(scripts.Script):
 
             if p.scripts is not None:
                 p.scripts.postprocess(p, processed)
+
+            self.current_inference_id = None
+            from modules import processing
+            processing.process_images_inner = self.hijacked_images_inner
+
             return processed
 
         self.hijacked_images_inner = processing.process_images_inner
@@ -405,9 +410,9 @@ class SageMakerUI(scripts.Script):
         processed.images = image_list
         processed.info = info_text
 
-        self.current_inference_id = None
-        from modules import processing
-        processing.process_images_inner = self.hijacked_images_inner
+        # self.current_inference_id = None
+        # from modules import processing
+        # processing.process_images_inner = self.hijacked_images_inner
         pass
 
     def _process_args_by_plugin(self, script_name, arg):


### PR DESCRIPTION
## Description

the previous change has made a stupid mistake which doesn't change back the original process image context.
this will cause the default generate button not working after generate on cloud

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update