### PR TITLE
fix: the stack deploy fail on inference stack

### DIFF
--- a/infrastructure/src/main.ts
+++ b/infrastructure/src/main.ts
@@ -72,6 +72,8 @@ export class Middleware extends Stack {
       'trains',
       'dataset',
       'datasets',
+      'inference',
+      'inference-api',
       api_train_path,
     ]);
 
@@ -97,7 +99,6 @@ export class Middleware extends Stack {
             <SDAsyncInferenceStackProps>{
               // env: devEnv,
               synthesizer: props.synthesizer,
-              api_gate_way: restApi.apiGateway,
               s3_bucket: s3BucketStore.s3Bucket,
               training_table: ddbTables.trainingTable,
               snsTopic: snsTopics.snsTopic,
@@ -106,6 +107,7 @@ export class Middleware extends Stack {
               sd_endpoint_deployment_job_table: ddbTables.endpointDeploymentJobTable,
               commonLayer: commonLayers.commonLayer,
               checkpointTable: ddbTables.checkPointTable,
+              routers: restApi.routers,
             },
     );
 

--- a/infrastructure/src/main.ts
+++ b/infrastructure/src/main.ts
@@ -80,7 +80,22 @@ export class Middleware extends Stack {
     const s3BucketStore = new S3BucketStore(this, 'sd-s3');
     const snsTopics = new SnsTopics(this, 'sd-sns', emailParam);
 
-    new SdTrainDeployStack(this, 'SdDreamBoothTrainStack', {
+
+    new SDAsyncInferenceStack(this, 'SdAsyncInferSt', <SDAsyncInferenceStackProps>{
+      routers: restApi.routers,
+      // env: devEnv,
+      s3_bucket: s3BucketStore.s3Bucket,
+      training_table: ddbTables.trainingTable,
+      snsTopic: snsTopics.snsTopic,
+      ecr_image_tag: ecrImageTagParam.valueAsString,
+      sd_inference_job_table: ddbTables.inferenceJobTable,
+      sd_endpoint_deployment_job_table: ddbTables.endpointDeploymentJobTable,
+      checkpointTable: ddbTables.checkPointTable,
+      commonLayer: commonLayers.commonLayer,
+      synthesizer: props.synthesizer,
+    });
+
+    new SdTrainDeployStack(this, 'SdDBTrainStack', {
       commonLayer: commonLayers.commonLayer,
       // env: devEnv,
       synthesizer: props.synthesizer,
@@ -91,25 +106,6 @@ export class Middleware extends Stack {
       s3Bucket: s3BucketStore.s3Bucket,
       snsTopic: snsTopics.snsTopic,
     });
-
-
-    new SDAsyncInferenceStack(
-      this,
-      'SdAsyncInferenceStack-dev',
-            <SDAsyncInferenceStackProps>{
-              // env: devEnv,
-              synthesizer: props.synthesizer,
-              s3_bucket: s3BucketStore.s3Bucket,
-              training_table: ddbTables.trainingTable,
-              snsTopic: snsTopics.snsTopic,
-              ecr_image_tag: ecrImageTagParam.valueAsString,
-              sd_inference_job_table: ddbTables.inferenceJobTable,
-              sd_endpoint_deployment_job_table: ddbTables.endpointDeploymentJobTable,
-              commonLayer: commonLayers.commonLayer,
-              checkpointTable: ddbTables.checkPointTable,
-              routers: restApi.routers,
-            },
-    );
 
     // Adding Outputs for apiGateway and s3Bucket
     new CfnOutput(this, 'ApiGatewayUrl', {

--- a/infrastructure/src/sd-inference/sd-async-inference-stack.ts
+++ b/infrastructure/src/sd-inference/sd-async-inference-stack.ts
@@ -8,7 +8,7 @@ import {
   RemovalPolicy,
   aws_ecr,
   CustomResource,
-  NestedStack, aws_dynamodb,
+  NestedStack, aws_dynamodb, aws_sns,
 } from 'aws-cdk-lib';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 
@@ -21,7 +21,7 @@ import * as eventSources from 'aws-cdk-lib/aws-lambda-event-sources';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
-import * as sns from 'aws-cdk-lib/aws-sns';
+// import * as sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 import { CreateInferenceJobApi, CreateInferenceJobApiProps } from './inference-job-create-api';
 import { RunInferenceJobApi, RunInferenceJobApiProps } from './inference-job-run-api';
@@ -39,7 +39,7 @@ export interface SDAsyncInferenceStackProps extends StackProps {
   routers: {[key: string]: Resource};
   s3_bucket: s3.Bucket;
   training_table: dynamodb.Table;
-  snsTopic: sns.Topic;
+  snsTopic: aws_sns.Topic;
   ecr_image_tag: string;
   sd_inference_job_table: aws_dynamodb.Table;
   sd_endpoint_deployment_job_table: aws_dynamodb.Table;
@@ -106,12 +106,12 @@ export class SDAsyncInferenceStack extends NestedStack {
     );
 
     // Create an SNS topic to get async inference result
-    const inference_result_topic = new sns.Topic(
+    const inference_result_topic = new aws_sns.Topic(
       this,
       'SNS-Receive-SageMaker-inference-success',
     );
 
-    const inference_result_error_topic = new sns.Topic(
+    const inference_result_error_topic = new aws_sns.Topic(
       this,
       'SNS-Receive-SageMaker-inference-error',
     );
@@ -126,7 +126,7 @@ export class SDAsyncInferenceStack extends NestedStack {
       endpointDeploymentJobTable: sd_endpoint_deployment_job_table,
       userNotifySNS:
                 props?.snsTopic ??
-                new sns.Topic(this, 'MyTopic', {
+                new aws_sns.Topic(this, 'MyTopic', {
                   displayName: 'My SNS Topic',
                 }),
       inference_ecr_url: inferenceECR_url,
@@ -249,12 +249,6 @@ export class SDAsyncInferenceStack extends NestedStack {
     });
 
     // Add a POST method with prefix inference
-
-
-    // if (!restful_api) {
-    //   throw new Error('restful_api is needed');
-    // }
-
     if (!inference) {
       throw new Error('inference is undefined');
     }

--- a/infrastructure/src/sd-inference/sd-sagemaker-inference-state-machine.ts
+++ b/infrastructure/src/sd-inference/sd-sagemaker-inference-state-machine.ts
@@ -80,12 +80,12 @@ export class SagemakerInferenceStateMachine {
         'ecr:UploadLayerPart',
         'ecr:CompleteLayerUpload',
         'ecr:PutImage',
-        'cloudwatch:PutMetricAlarm', 
+        'cloudwatch:PutMetricAlarm',
         'cloudwatch:PutMetricData',
         'sagemaker:DescribeEndpointConfig',
         'cloudwatch:DeleteAlarms',
         'cloudwatch:DescribeAlarms',
-        'sagemaker:UpdateEndpointWeightsAndCapacities'
+        'sagemaker:UpdateEndpointWeightsAndCapacities',
       ],
       resources: ['*'],
     });
@@ -116,10 +116,10 @@ export class SagemakerInferenceStateMachine {
     const endpointAutoScalingStatement = new iam.PolicyStatement({
       actions: [
         'application-autoscaling:RegisterScalableTarget',
-        'application-autoscaling:PutScalingPolicy'
+        'application-autoscaling:PutScalingPolicy',
       ],
-      resources: ['*']
-        })
+      resources: ['*'],
+    });
 
     const ddbStatement = new iam.PolicyStatement({
       actions: [
@@ -266,7 +266,7 @@ export class SagemakerInferenceStateMachine {
           INFERENCE_ECR_IMAGE_URL: inference_ecr_url,
         },
         role: lambdaCheckDeploymentStatusRole,
-        timeout: Duration.seconds(30)
+        timeout: Duration.seconds(30),
       },
     );
 

--- a/infrastructure/src/sd-train/sd-train-deploy-stack.ts
+++ b/infrastructure/src/sd-train/sd-train-deploy-stack.ts
@@ -199,6 +199,4 @@ export class SdTrainDeployStack extends NestedStack {
       srcRoot: this.srcRoot,
     });
   }
-
-
 }


### PR DESCRIPTION
## Description

currently, there are few customers report fail when deploy inference stack because of AWS::LAMBDA::Permission resource failed. After investigation, I found these issue related to apigateway and it's lambda during provision. The inference lambda has attached more than 30 apigateway triggers and related resources. Not 100% sure this is the problem. 

The delete stack still not going well, will fail during delete inference stack but retry will delete them all.

Fixes # (issue)

- removed the dependency between train stack and inference stack, we can now deploy them independently
- removed the custom resource to change apigateway stage and deploy prod stage in inference stack
- move main apigateway ramp up logic to main stack to gain more control of the api gateway  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update