### PR TITLE
feat: allow midware start from existing ddb and s3

### DIFF
--- a/infrastructure/src/sd-inference/sd-async-inference-stack.ts
+++ b/infrastructure/src/sd-inference/sd-async-inference-stack.ts
@@ -186,6 +186,7 @@ export class SDAsyncInferenceStack extends NestedStack {
           'sagemaker:DeleteEndpoint',
           'sagemaker:InvokeEndpoint',
           'sagemaker:InvokeEndpointAsync',
+          'application-autoscaling:DeregisterScalableTarget',
           's3:CreateBucket',
           's3:ListBucket',
           's3:GetObject',

--- a/infrastructure/src/sd-train/create-model-endpoint.ts
+++ b/infrastructure/src/sd-train/create-model-endpoint.ts
@@ -23,6 +23,8 @@ export interface CreateModelSageMakerEndpointProps {
   modelTable: aws_dynamodb.Table;
   commonLayer: aws_lambda.LayerVersion;
   userSnsTopic: aws_sns.Topic;
+  successTopic: aws_sns.Topic;
+  failureTopic: aws_sns.Topic;
 }
 
 export class CreateModelSageMakerEndpoint {
@@ -39,7 +41,6 @@ export class CreateModelSageMakerEndpoint {
   public readonly modelConfig: aws_sagemaker.CfnEndpointConfig;
   public readonly modelEndpoint: aws_sagemaker.CfnEndpoint;
 
-
   public readonly successTopic: aws_sns.Topic;
   public readonly failureTopic: aws_sns.Topic;
 
@@ -50,16 +51,8 @@ export class CreateModelSageMakerEndpoint {
     this.layer = props.commonLayer;
     this.rootSrc = props.rootSrc;
     this.userSnsTopic = props.userSnsTopic;
-
-
-    this.successTopic = new aws_sns.Topic(scope, `${id}-success-topic`, {
-      displayName: 'successCreateModel',
-      topicName: 'successCreateModel',
-    });
-    this.failureTopic = new aws_sns.Topic(scope, `${id}-failure-topic`, {
-      displayName: 'failureCreateModel',
-      topicName: 'failureCreateModel',
-    });
+    this.successTopic = <aws_sns.Topic> aws_sns.Topic.fromTopicArn(scope, `${id}-successTopic`, props.successTopic.topicArn);
+    this.failureTopic = <aws_sns.Topic> aws_sns.Topic.fromTopicArn(scope, `${id}-failureTopic`, props.failureTopic.topicArn);
 
     this.model = new aws_sagemaker.CfnModel(scope, `${this.id}-model`, <CfnModelProps>{
       executionRoleArn: this.sagemakerRole(scope).roleArn,

--- a/infrastructure/src/sd-train/model-update-status-api.ts
+++ b/infrastructure/src/sd-train/model-update-status-api.ts
@@ -23,6 +23,8 @@ import { AIGC_WEBUI_UTILS } from '../common/dockerImages';
 
 
 export interface UpdateModelStatusRestApiProps {
+  createModelFailureTopic: aws_sns.Topic;
+  createModelSuccessTopic: aws_sns.Topic;
   httpMethod: string;
   router: Resource;
   modelTable: aws_dynamodb.Table;
@@ -38,7 +40,7 @@ export interface UpdateModelStatusRestApiProps {
 export class UpdateModelStatusRestApi {
 
   public readonly sagemakerEndpoint: CreateModelSageMakerEndpoint;
-  private readonly imageUrl: string; 
+  private readonly imageUrl: string;
   private readonly machineType: string;
 
   private readonly src;
@@ -79,6 +81,8 @@ export class UpdateModelStatusRestApi {
       modelTable: this.modelTable,
       rootSrc: this.src,
       userSnsTopic: props.snsTopic,
+      successTopic: props.createModelSuccessTopic,
+      failureTopic: props.createModelFailureTopic,
     });
     this.sagemakerEndpoint.model.node.addDependency(dockerDeployment.customJob);
     // create lambda to trigger

--- a/infrastructure/src/sd-train/sd-train-deploy-stack.ts
+++ b/infrastructure/src/sd-train/sd-train-deploy-stack.ts
@@ -26,6 +26,8 @@ import { Database } from '../shared/database';
 
 // ckpt -> create_model -> model -> training -> ckpt -> inference
 export interface SdTrainDeployStackProps extends StackProps {
+  createModelSuccessTopic: aws_sns.Topic;
+  createModelFailureTopic: aws_sns.Topic;
   modelInfInstancetype: string;
   ecr_image_tag: string;
   database: Database;
@@ -63,10 +65,10 @@ export class SdTrainDeployStack extends NestedStack {
       srcRoot: this.srcRoot,
       trainTable: props.database.trainingTable,
     });
-
+    const checkPointTable = props.database.checkpointTable;
     // POST /train
     new CreateTrainJobApi(this, 'aigc-create-train', {
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       commonLayer: commonLayer,
       httpMethod: 'POST',
       modelTable: props.database.modelTable,
@@ -78,7 +80,7 @@ export class SdTrainDeployStack extends NestedStack {
 
     // PUT /train
     new UpdateTrainJobApi(this, 'aigc-put-train', {
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       commonLayer: commonLayer,
       httpMethod: 'PUT',
       modelTable: props.database.modelTable,
@@ -98,7 +100,7 @@ export class SdTrainDeployStack extends NestedStack {
       modelTable: props.database.modelTable,
       commonLayer: commonLayer,
       httpMethod: 'POST',
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
     });
 
     // GET /models
@@ -119,9 +121,11 @@ export class SdTrainDeployStack extends NestedStack {
       srcRoot: this.srcRoot,
       modelTable: props.database.modelTable,
       snsTopic: snsTopic,
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       trainMachineType: props.modelInfInstancetype,
       ecr_image_tag: props.ecr_image_tag,
+      createModelFailureTopic: props.createModelFailureTopic,
+      createModelSuccessTopic: props.createModelSuccessTopic,
     });
 
     // this.default_endpoint_name = modelStatusRestApi.sagemakerEndpoint.modelEndpoint.attrEndpointName;
@@ -129,7 +133,7 @@ export class SdTrainDeployStack extends NestedStack {
     // GET /checkpoints
     new ListAllCheckPointsApi(this, 'aigc-list-all-ckpts', {
       s3Bucket: s3Bucket,
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       commonLayer: commonLayer,
       httpMethod: 'GET',
       router: routers.checkpoints,
@@ -138,7 +142,7 @@ export class SdTrainDeployStack extends NestedStack {
 
     // POST /checkpoint
     new CreateCheckPointApi(this, 'aigc-create-ckpt', {
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       commonLayer: commonLayer,
       httpMethod: 'POST',
       router: routers.checkpoint,
@@ -148,7 +152,7 @@ export class SdTrainDeployStack extends NestedStack {
 
     // PUT /checkpoint
     new UpdateCheckPointApi(this, 'aigc-update-ckpt', {
-      checkpointTable: props.database.checkPointTable,
+      checkpointTable: checkPointTable,
       commonLayer: commonLayer,
       httpMethod: 'PUT',
       router: routers.checkpoint,
@@ -159,7 +163,7 @@ export class SdTrainDeployStack extends NestedStack {
     // POST /dataset
     new CreateDatasetApi(this, 'aigc-create-dataset', {
       commonLayer: commonLayer,
-      datasetInfoTable: props.database.datasetInfoTable,
+      datasetInfoTable: checkPointTable,
       datasetItemTable: props.database.datasetItemTable,
       httpMethod: 'POST',
       router: routers.dataset,

--- a/infrastructure/src/sd-train/sd-train-deploy-stack.ts
+++ b/infrastructure/src/sd-train/sd-train-deploy-stack.ts
@@ -163,7 +163,7 @@ export class SdTrainDeployStack extends NestedStack {
     // POST /dataset
     new CreateDatasetApi(this, 'aigc-create-dataset', {
       commonLayer: commonLayer,
-      datasetInfoTable: checkPointTable,
+      datasetInfoTable: props.database.checkPointTable,
       datasetItemTable: props.database.datasetItemTable,
       httpMethod: 'POST',
       router: routers.dataset,

--- a/infrastructure/src/sd-train/sd-train-deploy-stack.ts
+++ b/infrastructure/src/sd-train/sd-train-deploy-stack.ts
@@ -163,7 +163,7 @@ export class SdTrainDeployStack extends NestedStack {
     // POST /dataset
     new CreateDatasetApi(this, 'aigc-create-dataset', {
       commonLayer: commonLayer,
-      datasetInfoTable: props.database.checkPointTable,
+      datasetInfoTable: props.database.datasetInfoTable,
       datasetItemTable: props.database.datasetItemTable,
       httpMethod: 'POST',
       router: routers.dataset,

--- a/infrastructure/src/shared/database.ts
+++ b/infrastructure/src/shared/database.ts
@@ -1,95 +1,83 @@
-import { aws_dynamodb, aws_dynamodb as dynamodb, RemovalPolicy } from 'aws-cdk-lib';
-import { AttributeType } from 'aws-cdk-lib/aws-dynamodb';
+import { aws_dynamodb, CfnCondition, Fn, RemovalPolicy } from 'aws-cdk-lib';
+import { Attribute, AttributeType } from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 
+
 export class Database {
-  public readonly modelTable: aws_dynamodb.Table;
-  public readonly trainingTable: aws_dynamodb.Table;
-  public readonly checkPointTable: aws_dynamodb.Table;
-  public readonly datasetInfoTable: aws_dynamodb.Table;
-  public readonly datasetItemTable: aws_dynamodb.Table;
-  public readonly endpointDeploymentJobTable: aws_dynamodb.Table;
-  public readonly inferenceJobTable: aws_dynamodb.Table;
+  [index: string]: aws_dynamodb.Table;
 
-  constructor(scope: Construct, baseId: string) {
+  constructor(scope: Construct, baseId: string, useExist: string) {
+    interface tableProperties {
+      partitionKey: Attribute;
+      sortKey?: Attribute;
+    }
 
-    // Create DynamoDB table to store model job id
-    this.modelTable = new dynamodb.Table(scope, `${baseId}-ModelTable`, {
-      tableName: 'ModelTable',
-      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    // Create DynamoDB table to store training job id
-    this.trainingTable = new dynamodb.Table(scope, `${baseId}-TrainingTable`, {
-      tableName: 'TrainingTable',
-      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    this.checkPointTable = new dynamodb.Table(scope, `${baseId}-CheckpointTable`, {
-      tableName: 'CheckpointTable',
-      partitionKey: {
-        name: 'id',
-        type: dynamodb.AttributeType.STRING,
+    const tables: {[key: string]: tableProperties} = {
+      ModelTable: {
+        partitionKey: { name: 'id', type: aws_dynamodb.AttributeType.STRING },
       },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    this.datasetInfoTable = new dynamodb.Table(scope, `${baseId}-DatasetInfoTable`, {
-      tableName: 'DatasetInfoTable',
-      partitionKey: {
-        name: 'dataset_name',
-        type: dynamodb.AttributeType.STRING,
+      TrainingTable: {
+        partitionKey: { name: 'id', type: aws_dynamodb.AttributeType.STRING },
       },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    this.datasetItemTable = new dynamodb.Table(scope, `${baseId}-DatasetItemTable`, {
-      tableName: 'DatasetItemTable',
-      partitionKey: {
-        name: 'dataset_name',
-        type: dynamodb.AttributeType.STRING,
+      CheckpointTable: {
+        partitionKey: {
+          name: 'id',
+          type: aws_dynamodb.AttributeType.STRING,
+        },
       },
-      sortKey: {
-        name: 'sort_key',
-        type: AttributeType.STRING,
+      DatasetInfoTable: {
+        partitionKey: {
+          name: 'dataset_name',
+          type: aws_dynamodb.AttributeType.STRING,
+        },
       },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: RemovalPolicy.DESTROY,
-    });
-
-    // create Dynamodb table to save the inference job data
-    this.inferenceJobTable = new dynamodb.Table(scope, `${baseId}-InferenceJobTable`,
-      {
-        tableName: 'SDInferenceJobTable',
-        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-        removalPolicy: RemovalPolicy.DESTROY,
+      DatasetItemTable: {
+        partitionKey: {
+          name: 'dataset_name',
+          type: aws_dynamodb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'sort_key',
+          type: AttributeType.STRING,
+        },
+      },
+      SDInferenceJobTable: {
         partitionKey: {
           name: 'InferenceJobId',
-          type: dynamodb.AttributeType.STRING,
+          type: aws_dynamodb.AttributeType.STRING,
         },
-        pointInTimeRecovery: true,
       },
-    );
-
-    // create Dynamodb table to save the inference job data
-    this.endpointDeploymentJobTable = new dynamodb.Table(scope, `${baseId}-EndpointDeploymentJob`,
-      {
-        tableName: 'SDEndpointDeploymentJobTable',
-        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-        removalPolicy: RemovalPolicy.DESTROY,
+      SDEndpointDeploymentJobTable: {
         partitionKey: {
           name: 'EndpointDeploymentJobId',
-          type: dynamodb.AttributeType.STRING,
+          type: aws_dynamodb.AttributeType.STRING,
         },
-        pointInTimeRecovery: true,
+      },
+    };
+
+    const shouldCreateDDBTableCondition = new CfnCondition(
+      scope,
+      `${this.id}-shouldCreateDDBTable`,
+      {
+        expression: Fn.conditionEquals(useExist, 'no'),
       },
     );
-  }
 
+    // Create DynamoDB table to store model job id
+    for (let key in tables) {
+      const val = tables[key];
+
+      const newTable = new aws_dynamodb.Table(scope, `${baseId}-new-${key}`, {
+        tableName: key,
+        partitionKey: val.partitionKey,
+        billingMode: aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+        sortKey: val.sortKey,
+        removalPolicy: RemovalPolicy.RETAIN,
+      });
+
+      (newTable.node.defaultChild as aws_dynamodb.CfnTable).cfnOptions.condition = shouldCreateDDBTableCondition;
+
+      this[key.charAt(0).toLocaleLowerCase() + key.slice(1)] = <aws_dynamodb.Table> aws_dynamodb.Table.fromTableName(scope, `${baseId}-${key}`, key);
+    }
+  }
 }

--- a/infrastructure/src/shared/s3-bucket.ts
+++ b/infrastructure/src/shared/s3-bucket.ts
@@ -1,4 +1,4 @@
-import { aws_s3, RemovalPolicy } from 'aws-cdk-lib';
+import { aws_s3, CfnCondition, Fn, RemovalPolicy } from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
@@ -7,22 +7,32 @@ import { Construct } from 'constructs';
 export class S3BucketStore {
   public readonly s3Bucket: aws_s3.Bucket;
 
-  constructor(scope: Construct, id: string) {
-    // Define the CORS configuration
-    const corsRules: s3.CorsRule[] = [
+  constructor(scope: Construct, id: string, useExist: string, s3BucketName: string) {
+    const shouldCreateBucketCondition = new CfnCondition(
+      scope,
+      `${id}-shouldCreateBucket`,
       {
-        allowedHeaders: ['*'],
-        allowedMethods: [s3.HttpMethods.PUT, s3.HttpMethods.HEAD, s3.HttpMethods.GET],
-        allowedOrigins: ['*'],
-        exposedHeaders: ['ETag'],
+        expression: Fn.conditionEquals(useExist, 'no'),
       },
-    ];
+    );
 
     //The code that defines your stack goes here
-    this.s3Bucket = new s3.Bucket(scope, `${id}-aigc-bucket`, {
+    const newBucket = new s3.Bucket(scope, `${id}-aigc-newBucket`, {
+      bucketName: s3BucketName,
       blockPublicAccess: BlockPublicAccess.BLOCK_ACLS,
       removalPolicy: RemovalPolicy.RETAIN,
-      cors: corsRules,
+      cors: [
+        {
+          allowedHeaders: ['*'],
+          allowedMethods: [s3.HttpMethods.PUT, s3.HttpMethods.HEAD, s3.HttpMethods.GET],
+          allowedOrigins: ['*'],
+          exposedHeaders: ['ETag'],
+        },
+      ],
     });
+
+    (newBucket.node.defaultChild as s3.CfnBucket).cfnOptions.condition = shouldCreateBucketCondition;
+
+    this.s3Bucket = <aws_s3.Bucket> s3.Bucket.fromBucketName(scope, `${id}-aigc-bucket`, s3BucketName);
   }
 }

--- a/infrastructure/src/shared/sns-topics.ts
+++ b/infrastructure/src/shared/sns-topics.ts
@@ -1,20 +1,56 @@
-import { aws_iam, aws_kms, aws_sns, aws_sns_subscriptions as sns_subscriptions, CfnParameter } from 'aws-cdk-lib';
+import {
+  aws_iam,
+  aws_kms,
+  // aws_sns_subscriptions as sns_subscriptions,
+  CfnCondition,
+  Fn,
+  CfnParameter,
+  RemovalPolicy, Aws,
+} from 'aws-cdk-lib';
+import * as aws_sns from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
 
-export class SnsTopics {
-  public readonly snsTopic: aws_sns.Topic;
 
-  constructor(scope: Construct, id: string, emailParam: CfnParameter) {
+export class SnsTopics {
+
+  private static getTopicArnByTopicName(topicName: string): string {
+    return `arn:aws:sns:${Aws.REGION}:${Aws.ACCOUNT_ID}:${topicName}`;
+  }
+
+  public readonly snsTopic: aws_sns.Topic;
+  public readonly createModelSuccessTopic: aws_sns.Topic;
+  public readonly createModelFailureTopic: aws_sns.Topic;
+  public readonly inferenceResultTopic: aws_sns.Topic;
+  public readonly inferenceResultErrorTopic: aws_sns.Topic;
+
+  private readonly scope: Construct;
+  private readonly id: string;
+
+  constructor(scope: Construct, id: string, emailParam: CfnParameter, useExist: string) {
+
+    this.scope = scope;
+    this.id = id;
+
     // Check that props.emailParam and props.bucketName are not undefined
     if (!emailParam) {
       throw new Error('emailParam and bucketName must be provided');
     }
 
+
+    const shouldCreateSnsTopicCondition = new CfnCondition(
+      scope,
+      `${id}-shouldCreateSnsTopic`,
+      {
+        expression: Fn.conditionEquals(useExist, 'no'),
+      },
+    );
+
     // CDK parameters for SNS email address
     // Create SNS topic for notifications
     // const snsKmsKey = new kms.Key(this, 'SNSTrainEncryptionKey');
-    const snsKey = new aws_kms.Key(scope, `${id}-KmsMasterKey`, {
+    const newSnsKey = new aws_kms.Key(scope, `${id}-KmsMasterKey`, {
       enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.RETAIN,
       policy: new aws_iam.PolicyDocument({
         assignSids: true,
         statements: [
@@ -55,13 +91,37 @@ export class SnsTopics {
       }),
     });
 
-    this.snsTopic = new aws_sns.Topic(scope, 'StableDiffusionSnsTopic', {
-      masterKey: snsKey,
+    (newSnsKey.node.defaultChild as aws_kms.CfnKey).cfnOptions.condition = shouldCreateSnsTopicCondition;
+
+    const newUserTopic = new aws_sns.Topic(scope, `${id}-NewStableDiffusionSnsTopic`, {
+      masterKey: newSnsKey,
+      topicName: 'StableDiffusionSnsUserTopic',
+      displayName: 'StableDiffusionSnsUserTopic',
     });
+    newUserTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    (newUserTopic.node.defaultChild as aws_sns.CfnTopic).cfnOptions.condition = shouldCreateSnsTopicCondition;
+
+    this.snsTopic = <aws_sns.Topic> aws_sns.Topic.fromTopicArn(scope, `${id}-StableDiffusionSnsTopic`, SnsTopics.getTopicArnByTopicName('StableDiffusionSnsUserTopic'));
 
     // Subscribe user to SNS notifications
-    this.snsTopic.addSubscription(
-      new sns_subscriptions.EmailSubscription(emailParam.valueAsString),
-    );
+    // this.snsTopic.addSubscription(
+    //   new sns_subscriptions.EmailSubscription(emailParam.valueAsString),
+    // );
+
+    // Create an SNS topic to get async inference result
+    this.inferenceResultTopic = this.createOrImportTopic('ReceiveSageMakerInferenceSuccess', shouldCreateSnsTopicCondition);
+    this.inferenceResultErrorTopic = this.createOrImportTopic('ReceiveSageMakerInferenceError', shouldCreateSnsTopicCondition);
+    this.createModelSuccessTopic = this.createOrImportTopic('successCreateModel', shouldCreateSnsTopicCondition);
+    this.createModelFailureTopic = this.createOrImportTopic('failureCreateModel', shouldCreateSnsTopicCondition);
+  }
+
+  private createOrImportTopic(topicName: string, useExistCondition: CfnCondition): aws_sns.Topic {
+    const newTopic = new aws_sns.Topic(this.scope, `${this.id}-New${topicName}`, {
+      topicName: topicName,
+      displayName: topicName,
+    });
+    newTopic.applyRemovalPolicy(RemovalPolicy.RETAIN);
+    (newTopic.node.defaultChild as aws_sns.CfnTopic).cfnOptions.condition = useExistCondition;
+    return <aws_sns.Topic> aws_sns.Topic.fromTopicArn(this.scope, `${this.id}-${topicName}`, SnsTopics.getTopicArnByTopicName(topicName));
   }
 }


### PR DESCRIPTION
## Description

For issue #165, the user need to delete and re-create stack from the existing data. 

- added new parameters when stack creation: create_from_exist['yes' or 'no'], exist_bucket['the s3 bucket the user want to reuse or be created']
- when create from exist is yes, no ddb, s3, and sns topic will be recreated, stack will use existing ones (by resource name). if not found, will fail.
- when create from exist is no, it will create all new resources

Test has been down locally:
- create stack from scratch, all works fine
- delete stack and ddb, s3, topics and endpoint related iam roles will stay.
- create again from existing resources works fine:

     - inference use previously created endpoint and models works fine
     - inference result from previous stack works fine    

Fixes # (issue)

issue #165

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update