### PR TITLE
fix: deleted inference endpoint is still selectable

### DIFF
--- a/middleware_api/lambda/inference_v2/inference_api.py
+++ b/middleware_api/lambda/inference_v2/inference_api.py
@@ -344,7 +344,7 @@ def _schedule_inference_endpoint(endpoint_name, user_id):
         available_endpoints = []
         for row in sagemaker_endpoint_raws:
             endpoint = EndpointDeploymentJob(**ddb_service.deserialize(row))
-            if endpoint.endpoint_status != 'InService':
+            if endpoint.endpoint_status != 'InService' or endpoint.status == 'deleted':
                 continue
 
             if check_user_permissions(endpoint.owner_group_or_role, user_roles, user_id):


### PR DESCRIPTION
## Description

deleted endpoint is still can be selected when infering

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update