### PR TITLE
feat: remove .json method and improved get endpoint name

### DIFF
--- a/aws_extension/cloud_api_manager/api_manager.py
+++ b/aws_extension/cloud_api_manager/api_manager.py
@@ -79,9 +79,7 @@ class CloudApiManager:
         deployment_url = f"{self.auth_manger.api_url}endpoints"
 
         try:
-            response = requests.delete(deployment_url, json=payload, headers=self._get_headers_by_user(user_token))
-            response = response.json()
-            logger.debug(f"response for rest api {response}")
+            requests.delete(deployment_url, json=payload, headers=self._get_headers_by_user(user_token))
             return "Delete Endpoint Successfully"
         except Exception as e:
             logger.error(e)
@@ -252,10 +250,8 @@ class CloudApiManager:
         raw_resp = requests.delete(f'{cloud_auth_manager.api_url}users',
                                    json=payload,
                                    headers=self._get_headers_by_user(user_token))
-        raw_resp.raise_for_status()
-        resp = raw_resp.json()
         if raw_resp.status_code != 204:
-            raise Exception(resp['message'])
+            raise Exception(raw_resp.json()['message'])
         return True
 
     def list_models_on_cloud(self, username, user_token="", types='Stable-diffusion', status='Active'):

--- a/aws_extension/cloud_api_manager/api_manager.py
+++ b/aws_extension/cloud_api_manager/api_manager.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import logging
 
 import requests
@@ -79,7 +78,9 @@ class CloudApiManager:
         deployment_url = f"{self.auth_manger.api_url}endpoints"
 
         try:
-            requests.delete(deployment_url, json=payload, headers=self._get_headers_by_user(user_token))
+            resp = requests.delete(deployment_url, json=payload, headers=self._get_headers_by_user(user_token))
+            if resp.status_code != 204:
+                raise Exception(resp.json()['message'])
             return "Delete Endpoint Successfully"
         except Exception as e:
             logger.error(e)
@@ -199,7 +200,8 @@ class CloudApiManager:
             "creator": creator
         }
 
-        raw_resp = requests.post(f'{cloud_auth_manager.api_url}roles', json=payload, headers=self._get_headers_by_user(user_token))
+        raw_resp = requests.post(f'{cloud_auth_manager.api_url}roles', json=payload,
+                                 headers=self._get_headers_by_user(user_token))
         raw_resp.raise_for_status()
         resp = raw_resp.json()
         if raw_resp.status_code != 200:
@@ -300,7 +302,8 @@ class CloudApiManager:
         if not self.auth_manger.enableAuth:
             return []
 
-        raw_response = requests.get(url=f'{self.auth_manger.api_url}datasets/{dataset_name}', headers=self._get_headers_by_user(user_token))
+        raw_response = requests.get(url=f'{self.auth_manger.api_url}datasets/{dataset_name}',
+                                    headers=self._get_headers_by_user(user_token))
         raw_response.raise_for_status()
         # todo: the s3 presign url is not ready as content type to img
         resp = raw_response.json()['data']

--- a/middleware_api/lambda/endpoints/endpoint_event.py
+++ b/middleware_api/lambda/endpoints/endpoint_event.py
@@ -3,8 +3,8 @@ import os
 from datetime import datetime
 
 import boto3
-
 from common.ddb_service.client import DynamoDbUtilsService
+from endpoints.delete_endpoints import get_endpoint_with_endpoint_name
 from libs.enums import EndpointStatus
 
 sagemaker_endpoint_table = os.environ.get('DDB_ENDPOINT_DEPLOYMENT_TABLE_NAME')
@@ -183,23 +183,6 @@ def update_endpoint_field(endpoint_deployment_job_id, field_name, field_value):
         field_name=field_name,
         value=field_value
     )
-
-
-def get_endpoint_with_endpoint_name(endpoint_name):
-    try:
-        record_list = ddb_service.scan(table=sagemaker_endpoint_table, filters={
-            'endpoint_name': endpoint_name,
-        })
-
-        if len(record_list) == 0:
-            logger.error("There is no endpoint deployment job info item with endpoint name: " + endpoint_name)
-            return {}
-
-        logger.info(record_list[0])
-        return record_list[0]
-    except Exception as e:
-        logger.error(e)
-        return {}
 
 
 def get_business_status(status):


### PR DESCRIPTION
## Description

- do not use .json method when status code is 204
- unique `get_endpoint_with_endpoint_name` method for both caller
- can't delete endpoint when status is `Creating` or `Updating`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update