### PR TITLE
fix: update requests version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.26.28
-requests
+requests>2.27.0
 urllib
 psutil==5.9.5
 nest_asyncio==1.5.6


### PR DESCRIPTION
## Description

Update requests version to avoid the following error

      File "/home/ec2-user/SageMaker/stable-diffusion-webui/extensions/stable-diffusion-aws-extension/aws_extension/sagemaker_ui.py", line 19, in <module>
        from requests.exceptions import JSONDecodeError
    ImportError: cannot import name 'JSONDecodeError' from 'requests.exceptions' (/home/ec2-user/SageMaker/stable-diffusion-webui/venv/lib/python3.10/site-packages/requests/exceptions.py)

[Community.streamset issue](https://community.streamsets.com/community-articles-and-got-a-question-7/importerror-cannot-import-name-jsondecodeerror-from-requests-exceptions-2033)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)